### PR TITLE
Separate hostname and IP address in remote endpoint

### DIFF
--- a/PyTAPS/connection.py
+++ b/PyTAPS/connection.py
@@ -51,10 +51,12 @@ class Connection:
         it will be used.
     """
     async def connect(self):
-        # Resolve remote endpoint
-        remote_info = await self.loop.getaddrinfo(self.remote_endpoint.address,
+        if self.remote_endpoint.hostname is not None:
+            # Resolve remote endpoint
+            remote_info = await self.loop.getaddrinfo(self.remote_endpoint.hostname,
                                                   self.remote_endpoint.port)
-        self.remote_endpoint.address = remote_info[0][4][0]
+            self.remote_endpoint.address = remote_info[0][4][0]
+            print_time("Resolved hostname " + self.remote_endpoint.hostname + " to " + self.remote_endpoint.address, color)
 
         # Attempt connection
         try:

--- a/PyTAPS/endpoint.py
+++ b/PyTAPS/endpoint.py
@@ -24,12 +24,13 @@ class RemoteEndpoint:
     def __init__(self):
         self.address = None
         self.port = None
+        self.hostname = None
 
     def with_address(self, address):
         self.address = address
 
     def with_hostname(self, name):
-        self.address = name
+        self.hostname = name
 
     def with_port(self, portNumber):
         self.port = portNumber

--- a/testClient.py
+++ b/testClient.py
@@ -1,6 +1,7 @@
 import PyTAPS as taps
 import asyncio
 import sys
+import ipaddress
 color = "yellow"
 
 
@@ -39,7 +40,7 @@ class TestClient():
         self.loop.stop()
 
     async def handle_ready(self, connection):
-        taps.print_time("Ready cb received.", color)
+        taps.print_time("Ready cb received from connection to " + connection.remote_endpoint.address + ":" + str(connection.remote_endpoint.port) + " (hostname: " + str(connection.remote_endpoint.hostname) + ")", color)
 
         # Set connection callbacks
         self.connection.on_sent(self.handle_sent)
@@ -66,7 +67,12 @@ class TestClient():
 
         # See if a remote and/or local address/port has been specified
         if len(sys.argv) >= 3:
-            ep.with_address(str(sys.argv[1]))
+            try:
+                ipaddress.ip_address(sys.argv[1])
+                ep.with_address(str(sys.argv[1]))
+            except ValueError:
+                taps.print_time("Not a valid IP address: " + sys.argv[1] + " - assuming it's a hostname", color)
+                ep.with_hostname(str(sys.argv[1]))
             ep.with_port(int(sys.argv[2]))
             if len(sys.argv) >= 4:
                 lp = taps.LocalEndpoint()


### PR DESCRIPTION
This PR splits hostname and IP address in the RemoteEndpoint, so they are stored separately.
DNS only occurs if the hostname is not None.
The testClient automatically checks if the first argument is a valid IP address, and if not, it assumes it's a hostname.