### PR TITLE
Remote endpoint racing

### DIFF
--- a/examples/echo_example/echoServer.py
+++ b/examples/echo_example/echoServer.py
@@ -57,6 +57,8 @@ class TestServer():
             lp.with_interface(args.interface)
         if args.local_address:
             lp.with_address(args.local_address)
+        if args.local_host:
+            lp.with_hostname(args.local_host)
         if args.local_port:
             lp.with_port(args.local_port)
 
@@ -98,7 +100,9 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser(description='PyTAPS test server.')
     ap.add_argument('--interface', '-i', nargs=1, default=None)
     ap.add_argument('--local-address', '--address', '-a', nargs='?',
-                    default='::1')
+                    default=None)
+    ap.add_argument('--local-host', '--host', '-H', nargs='?',
+                    default='localhost')
     ap.add_argument('--local-port', '--port', '-l', type=int, nargs='?',
                     default=6666)
     ap.add_argument('--local-identity', type=str, nargs=1, default=None)

--- a/examples/minimal_example/minimalClient.py
+++ b/examples/minimal_example/minimalClient.py
@@ -10,7 +10,7 @@ class TestClient():
 
     async def main(self):
         ep = taps.RemoteEndpoint()
-        ep.with_address("localhost")
+        ep.with_hostname("localhost")
         ep.with_port(6666)
         tp = taps.TransportProperties()
 

--- a/examples/minimal_example/minimalServer.py
+++ b/examples/minimal_example/minimalServer.py
@@ -14,7 +14,7 @@ class TestServer():
 
     async def main(self):
         lp = taps.LocalEndpoint()
-        lp.with_address("localhost")
+        lp.with_hostname("localhost")
         lp.with_port(6666)
         tp = taps.TransportProperties()
 

--- a/pytaps/connection.py
+++ b/pytaps/connection.py
@@ -59,16 +59,22 @@ class Connection():
                                         self.security_parameters.identity)
             for cert in self.security_parameters.trustedCA:
                 self.security_context.load_verify_locations(cert)
-        # Resolve address
-        remote_info = await self.loop.getaddrinfo(
-            self.remote_endpoint.host_name, self.remote_endpoint.port)
 
-        # Concat v6 and v4 address lists, making sure we try v6 first
-        all_addrs_v6 = list(set([ info[4][0] for info in remote_info if info[0] == socket.AddressFamily.AF_INET6]))
-        all_addrs_v4 = list(set([ info[4][0] for info in remote_info if info[0] == socket.AddressFamily.AF_INET]))
-        all_addrs = all_addrs_v6 + all_addrs_v4
+        if self.remote_endpoint.host_name is not None:
+            # Resolve address
+            remote_info = await self.loop.getaddrinfo(
+                self.remote_endpoint.host_name, self.remote_endpoint.port)
+            # Concat v6 and v4 address lists, making sure we try v6 first
+            all_addrs_v6 = list(set([ info[4][0] for info in remote_info if info[0] == socket.AddressFamily.AF_INET6]))
+            all_addrs_v4 = list(set([ info[4][0] for info in remote_info if info[0] == socket.AddressFamily.AF_INET]))
+            all_addrs = all_addrs_v6 + all_addrs_v4
+            print_time("Resolved " + str(self.remote_endpoint.host_name) + " to " + str(all_addrs), color)
 
-        print_time("Resolved " + str(self.remote_endpoint.host_name) + " to " + str(all_addrs), color)
+        else:
+            all_addrs = self.remote_endpoint.address
+            print_time("Not resolving - using address " + str(self.remote_endpoint.address) + " --> " + str(all_addrs), color)
+
+        # Get all combinations of protocols and remote IP addresses to race them
         candidate_set = [ protocol + (address,) for address in all_addrs for protocol in protocol_candidates ]
 
         # Attempt to establish a connection with each candidate
@@ -81,7 +87,7 @@ class Connection():
             print_time("Trying candidate protocol: " + str(candidate[0]) + " and address: " + str(candidate[2]), color)
             if candidate[0] == 'udp':
                 self.protocol = 'udp'
-                print_time("Creating UDP connect task with remote addr " + str(candidate[2]), color)
+                print_time("Creating UDP connect task with remote addr " + str(candidate[2]) + ", port " + str(self.remote_endpoint.port), color)
                 self.remote_endpoint.address = candidate[2]
                 multicast_receiver = False
                 if self.local_endpoint:
@@ -106,10 +112,14 @@ class Connection():
 
                 if not multicast_receiver:
                     # If we do not have multicast, create a datagram endpoint
+                    print_time("endpoint: " + str(self.remote_endpoint) + ", address: " + str(self.remote_endpoint.address) + ", " + str(self.remote_endpoint.port), color)
                     task = self.loop.create_task(self.loop.create_datagram_endpoint(
                                         lambda: UdpTransport(connection=self, remote_endpoint=self.remote_endpoint),
                                         remote_addr=(self.remote_endpoint.address,
                                                      self.remote_endpoint.port)))
+
+                print_time("Not racing multiple addrs for UDP -- stop racing", color)
+                break
 
             elif candidate[0] == 'tcp':
                 self.protocol = 'tcp'
@@ -122,6 +132,7 @@ class Connection():
                                     self.remote_endpoint.port,
                                     ssl=self.security_context,
                                     server_hostname=(self.remote_endpoint.host_name if self.security_context else None)))
+                # Wait before starting next connection attempt
                 await asyncio.sleep(RACING_DELAY)
 
     async def send_message(self, data):

--- a/pytaps/connection.py
+++ b/pytaps/connection.py
@@ -32,6 +32,7 @@ class Connection():
                 self.active = preconnection.active
                 self.framer = preconnection.framer
                 self.set_callbacks(preconnection)
+                self.sleeper_for_racing = SleepClassForRacing()
                 self.pending = []
                 # Security Context for SSL
                 self.security_context = None
@@ -110,7 +111,7 @@ class Connection():
                                     ssl=self.security_context,
                                     server_hostname=(self.remote_endpoint.host_name if self.security_context else None)))
                 # Wait before starting next connection attempt
-                await asyncio.sleep(RACING_DELAY)
+                await self.sleeper_for_racing.sleep(RACING_DELAY)
 
     async def send_message(self, data):
         """ Attempts to send data on the connection.

--- a/pytaps/endpoint.py
+++ b/pytaps/endpoint.py
@@ -7,7 +7,8 @@ class LocalEndpoint:
     def __init__(self):
         self.interface = None
         self.port = None
-        self.address = None
+        self.address = []
+        self.host_name = None
 
     def with_interface(self, interface):
         """Specifies which interface the local endpoint should use.
@@ -24,7 +25,16 @@ class LocalEndpoint:
             address (string, required): Address in the form of an IPv4
                 or IPv6 address.
         """
-        self.address = address
+        self.address.append(address)
+
+    def with_hostname(self, hostname):
+        """Specifies a hostname to listen on the resolved addresses.
+
+        Attributes:
+            hostname (hostname, required): Domain name, e.g., localhost.
+        """
+        self.host_name = hostname
+
 
     def with_port(self, portNumber):
         """Specifies which port the local endpoint should use.

--- a/pytaps/listener.py
+++ b/pytaps/listener.py
@@ -8,7 +8,6 @@ from .endpoint import LocalEndpoint, RemoteEndpoint
 from .utility import *
 from .transports import *
 from .multicast import do_join, do_leave
-import ipaddress
 
 color = "cyan"
 

--- a/pytaps/listener.py
+++ b/pytaps/listener.py
@@ -1,5 +1,6 @@
 import asyncio
 import ssl
+import ipaddress
 from .connection import Connection
 from .securityParameters import SecurityParameters
 from .transportProperties import *
@@ -36,10 +37,10 @@ class Listener():
         print_time("Starting listener.", color)
 
         # Create set of candidate protocols
-        candidate_set = self.create_candidates()
+        protocol_candidates = self.create_candidates()
 
         # If the candidate set is empty issue an InitiateError cb
-        if not candidate_set:
+        if not protocol_candidates:
             print_time("Protocol selection Error occured.", color)
             if self.initiate_error:
                 self.loop.create_task(self.initiate_error())
@@ -56,28 +57,47 @@ class Listener():
                                         self.security_parameters.identity)
             for cert in self.security_parameters.trustedCA:
                 self.security_context.load_verify_locations(cert)
+
+        if len(self.local_endpoint.address) < 1 and self.local_endpoint.host_name is not None:
+            # No address to listen on yet -- resolve hostname
+            endpoint_info = await self.loop.getaddrinfo(
+                self.local_endpoint.host_name, self.local_endpoint.port)
+            all_addrs = list(set([ info[4][0] for info in endpoint_info]))
+            print_time("Resolved " + str(self.local_endpoint.host_name) + " to " + str(all_addrs), color)
+        else:
+            all_addrs = self.local_endpoint.address
+            print_time("Not resolving - using address(es) " + str(self.local_endpoint.address) + " --> " + str(all_addrs), color)
+
+        # Get all combinations of protocols and remote IP addresses
+        # to listen on all of them
+        candidate_set = [ protocol + (address,) for address in all_addrs for protocol in protocol_candidates ]
+
         # Attempt to set up the appropriate listener for the candidate protocol
         for candidate in candidate_set:
             try:
                 if candidate[0] == 'udp':
                     self.protocol = 'udp'
+                    self.local_endpoint.address = candidate[2]
+                    print_time("UDP local endpoint: address " + str(self.local_endpoint.address) + " port: " + str(self.local_endpoint.port), color)
                     await self.loop.create_datagram_endpoint(
                                     lambda: DatagramHandler(self),
-                                    local_addr=(self.local_endpoint.interface,
+                                    local_addr=(self.local_endpoint.address,
                                                 self.local_endpoint.port))
                 elif candidate[0] == 'tcp':
                     self.protocol = 'tcp'
+                    self.local_endpoint.address = candidate[2]
+                    print_time("TCP local endpoint: address " + str(self.local_endpoint.address) + " port: " + str(self.local_endpoint.port))
                     server = await self.loop.create_server(
                                     lambda: StreamHandler(self),
-                                    self.local_endpoint.interface,
+                                    self.local_endpoint.address,
                                     self.local_endpoint.port,
                                     ssl=self.security_context)
-            except:
-                print_time("Listen Error occured.", color)
+            except Exception as err:
+                print_time("Listen Error occured: " + str(err), color)
                 if self.listen_error:
                     self.loop.create_task(self.listen_error())
 
-            print_time("Starting " + self.protocol + " Listener on " +
+            print_time("Started " + self.protocol + " Listener on " +
                        (str(self.local_endpoint.address) if
                         self.local_endpoint.address else "default") + ":" +
                        str(self.local_endpoint.port), color)

--- a/pytaps/transports.py
+++ b/pytaps/transports.py
@@ -126,7 +126,7 @@ class UdpTransport(TransportLayer):
         self.transport = transport
         for t in self.connection.pending:
             t.cancel()
-        print_time("Connected successfully UDP.", color)
+        print_time("Connected successfully UDP to " + str(self.connection.remote_endpoint.address) + ":" + str(self.connection.remote_endpoint.port) + ".", color)
         self.connection.state = ConnectionState.ESTABLISHED
         if self.connection.framer:
             # Send a start even to the framer and wait for a reply
@@ -138,7 +138,7 @@ class UdpTransport(TransportLayer):
     async def write(self, data):
         """ Sends udp data
         """
-        print_time("Writing UDP data.", color)
+        print_time("Writing UDP data to " + str(self.connection.remote_endpoint.address) + ":" + str(self.connection.remote_endpoint.port) + ".", color)
         try:
             # See if the udp flow was the result of passive or active open
             if self.connection.active:

--- a/pytaps/transports.py
+++ b/pytaps/transports.py
@@ -288,6 +288,7 @@ class TcpTransport(TransportLayer):
         self.transport = transport
         print_time("Connected successfully on TCP.", color)
         self.connection.state = ConnectionState.ESTABLISHED
+        self.connection.sleeper_for_racing.cancel_all()
         if self.connection.framer:
             # Send a start even to the framer and wait for a reply
             await self.connection.framer.handle_start(self.connection)

--- a/pytaps/utility.py
+++ b/pytaps/utility.py
@@ -12,3 +12,24 @@ class ConnectionState(Enum):
 
 def print_time(msg="", color="red"):
     print(colored(str(datetime.datetime.now())+": "+msg, color))
+
+# Define our own sleep function which keeps track of its running calls
+# so we can cancel them once the Connection is established
+# https://stackoverflow.com/questions/37209864/interrupt-all-asyncio-sleep-currently-executing
+class SleepClassForRacing:
+    tasks = set()
+
+    async def sleep(self, delay, result=None, *, loop=None):
+        coro = asyncio.sleep(delay, result=result, loop=loop)
+        task = asyncio.ensure_future(coro)
+        self.tasks.add(task)
+        try:
+            return await task
+        except asyncio.CancelledError:
+            return result
+        finally:
+            self.tasks.remove(task)
+
+    def cancel_all(self):
+        for task in self.tasks:
+            task.cancel()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -44,13 +44,13 @@ class TestClient():
 		self.connection.on_closed(self.handle_closed)
 		msgref = await self.connection.send_message(self.data_to_send)
 
-	async def main(self, data_to_send="Hello\n", stop_at_sent=False, remote_port=6666, reliable=False, yangfile=None, trust_ca=None, local_identity=None):
+	async def main(self, data_to_send="Hello\n", stop_at_sent=False, remote_hostname="localhost", remote_port=6666, reliable=False, yangfile=None, trust_ca=None, local_identity=None):
 		self.data_to_send = data_to_send
 		self.stop_at_sent = stop_at_sent
 		self.yangfile = yangfile
 
 		ep = taps.RemoteEndpoint()
-		ep.with_hostname("localhost")
+		ep.with_hostname(remote_hostname)
 		ep.with_port(remote_port)
 		tp = taps.TransportProperties()
 
@@ -178,5 +178,20 @@ def test_echo_tls_yang():
 		loop.run_forever()
 
 		assert client.received_data.decode() == teststring
+	finally:
+		loop.close()
+
+@pytest.mark.timeout(TEST_TIMEOUT)
+def test_http():
+	hostname = "www.ietf.org"
+	teststring = "GET / HTTP/1.1\r\nHost: " + hostname + "\r\n\r\n"
+	loop = asyncio.new_event_loop()
+	try:
+		client = TestClient()
+		asyncio.set_event_loop(loop)
+		task = loop.create_task(client.main(data_to_send=teststring, remote_hostname=hostname, remote_port=80, reliable=True))
+		loop.run_forever()
+
+		assert "HTTP" in client.received_data.decode()
 	finally:
 		loop.close()


### PR DESCRIPTION
This PR does the following:

- After resolving a remote hostname, race all combinations of protocol and remote IP addresses (Prefer IPv6. Do not race multiple remote addresses for UDP.)
- After each racing attempt, wait for a RACING_DELAY (current 100 ms)
- Add support for local hostnames (e.g., localhost), listen on all resolved IP addresses, support listening on multiple IP addresses
- Only try to resolve when there is actually a hostname. Otherwise, use IP address directly
- Fix bug in connection.py where comparing the ConnectionState failed due to duplicate import
- Add an HTTP test