### PR TITLE
Local interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ For a client with a model specified in `examples/yang_example/test-client2.json`
 
 - Python 3.7 or above
 - termcolor (pip install termcolor)
+- netifaces (pip install netifaces)
 - pytest, pytest-asyncio, pytest-timeout (for tests)
 
 ### Running

--- a/examples/echo_example/echoServer.py
+++ b/examples/echo_example/echoServer.py
@@ -59,6 +59,9 @@ class TestServer():
             lp.with_address(args.local_address)
         if args.local_host:
             lp.with_hostname(args.local_host)
+        # If nothing to listen on has been specified, listen on localhost
+        if not args.interface and not args.local_address and not args.local_host:
+            lp.with_hostname("localhost")
         if args.local_port:
             lp.with_port(args.local_port)
 
@@ -102,7 +105,7 @@ if __name__ == "__main__":
     ap.add_argument('--local-address', '--address', '-a', nargs='?',
                     default=None)
     ap.add_argument('--local-host', '--host', '-H', nargs='?',
-                    default='localhost')
+                    default=None)
     ap.add_argument('--local-port', '--port', '-l', type=int, nargs='?',
                     default=6666)
     ap.add_argument('--local-identity', type=str, nargs=1, default=None)

--- a/pytaps/connection.py
+++ b/pytaps/connection.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import sys
 import ssl
+import netifaces
 from .endpoint import LocalEndpoint, RemoteEndpoint
 from .transportProperties import *
 from .utility import *
@@ -68,20 +69,42 @@ class Connection():
 
         if self.remote_endpoint.host_name is not None:
             # Resolve address
+            # FIXME: Unfortunately, asyncio getaddrinfo does not allow to resolve on specific interfaces
+            # FIXME: Consider migrating to something better, e.g., getdns
             remote_info = await self.loop.getaddrinfo(
                 self.remote_endpoint.host_name, self.remote_endpoint.port)
             # Concat v6 and v4 address lists, making sure we try v6 first
-            all_addrs_v6 = list(set([ info[4][0] for info in remote_info if info[0] == socket.AddressFamily.AF_INET6]))
-            all_addrs_v4 = list(set([ info[4][0] for info in remote_info if info[0] == socket.AddressFamily.AF_INET]))
-            all_addrs = all_addrs_v6 + all_addrs_v4
-            print_time("Resolved " + str(self.remote_endpoint.host_name) + " to " + str(all_addrs), color)
+            remote_addrs_v6 = list(set([ info[4][0] for info in remote_info if info[0] == socket.AddressFamily.AF_INET6]))
+            remote_addrs_v4 = list(set([ info[4][0] for info in remote_info if info[0] == socket.AddressFamily.AF_INET]))
+            remote_addrs = remote_addrs_v6 + remote_addrs_v4
+            print_time("Resolved " + str(self.remote_endpoint.host_name) + " to " + str(remote_addrs), color)
 
         else:
-            all_addrs = self.remote_endpoint.address
-            print_time("Not resolving - using address " + str(self.remote_endpoint.address) + " --> " + str(all_addrs), color)
+            remote_addrs = self.remote_endpoint.address
+            print_time("Not resolving - using address " + str(self.remote_endpoint.address) + " --> " + str(remote_addrs), color)
 
-        # Get all combinations of protocols and remote IP addresses to race them
-        candidate_set = [ protocol + (address,) for address in all_addrs for protocol in protocol_candidates ]
+        if self.local_endpoint is not None:
+            # Local interface specified --> try local addresses on that interface
+            for local_interface in self.local_endpoint.interface:
+                try:
+                    # Unfortunately, link-local IPv6 addresses don't work
+                    # because they're broken in asyncio: https://bugs.python.org/issue35545
+                    local_v6_addrs = [ entry['addr'] for entry in netifaces.ifaddresses(local_interface)[netifaces.AF_INET6] if entry['addr'][:4] != "fe80" ]
+                    local_v4_addrs = [ entry['addr'] for entry in netifaces.ifaddresses(local_interface)[netifaces.AF_INET] ]
+                    print_time("Trying addresses of local interface " + str(self.local_endpoint.interface) + " --> " + str(local_v6_addrs) + ", " + str(local_v4_addrs), color)
+                except ValueError as err:
+                    print_time("Cannot get IP addresses for " + str(self.local_endpoint.interface) + ": " + str(err), color)
+                    # TODO throw error
+            # Build candidate set for racing
+            # based on combinations of protocol, local and remote IP address
+            candidate_set = [ protocol + (remote_address,) + (local_address,) for remote_address in remote_addrs_v6 for protocol in protocol_candidates for local_address in local_v6_addrs ]
+            candidate_set += [ protocol + (remote_address,) + (local_address,) for remote_address in remote_addrs_v4 for protocol in protocol_candidates for local_address in local_v4_addrs ]
+            print_time("Final Candidates: " + str(candidate_set))
+
+        else:
+            # Build candidate set for racing
+            # based on combinations of protocol and remote IP address
+            candidate_set = [ protocol + (address,) for address in remote_addrs for protocol in protocol_candidates ]
 
         # Attempt to establish a connection with each candidate
         for candidate in candidate_set:
@@ -90,7 +113,14 @@ class Connection():
                 print_time("Connection established -- stop racing", color)
                 break
 
-            print_time("Trying candidate protocol: " + str(candidate[0]) + " and address: " + str(candidate[2]), color)
+            print_time("Trying candidate protocol: " + str(candidate[0]) + " and remote address: " + str(candidate[2]) + ( " and local address: " + str(candidate[3]) if len(candidate) > 3 else "" ), color)
+            if len(candidate) > 3:
+                # bind to a specific local address
+                local_address_to_use = (candidate[3], None)
+                self.local_endpoint.address = candidate[3]
+            else:
+                local_address_to_use = None
+
             if candidate[0] == 'udp':
                 self.protocol = 'udp'
                 print_time("Creating UDP connect task with remote addr " + str(candidate[2]) + ", port " + str(self.remote_endpoint.port), color)
@@ -100,7 +130,8 @@ class Connection():
                 task = self.loop.create_task(self.loop.create_datagram_endpoint(
                                     lambda: UdpTransport(connection=self, remote_endpoint=self.remote_endpoint),
                                     remote_addr=(self.remote_endpoint.address,
-                                                 self.remote_endpoint.port)))
+                                                 self.remote_endpoint.port),
+                                    local_addr=local_address_to_use))
 
                 print_time("Not racing multiple addrs for UDP -- stop racing", color)
                 break
@@ -115,7 +146,8 @@ class Connection():
                                     self.remote_endpoint.address,
                                     self.remote_endpoint.port,
                                     ssl=self.security_context,
-                                    server_hostname=(self.remote_endpoint.host_name if self.security_context else None)))
+                                    server_hostname=(self.remote_endpoint.host_name if self.security_context else None),
+                                    local_addr = local_address_to_use))
                 # Wait before starting next connection attempt
                 await self.sleeper_for_racing.sleep(RACING_DELAY)
 

--- a/pytaps/listener.py
+++ b/pytaps/listener.py
@@ -76,15 +76,16 @@ class Listener():
         if len(self.local_endpoint.address) > 0:
             all_addrs += self.local_endpoint.address
             print_time("Adding addresses to listen: " + str(self.local_endpoint.address) + " --> " + str(all_addrs), color)
-        for local_interface in self.local_endpoint.interface:
-            try:
-                # Unfortunately, listening on link-local IPv6 addresses does not work
-                # because it's broken in asyncio: https://bugs.python.org/issue35545
-                all_addrs += [ entry['addr'] for entry in netifaces.ifaddresses(local_interface)[netifaces.AF_INET6] if entry['addr'][:4] != "fe80" ]
-                all_addrs += [ entry['addr'] for entry in netifaces.ifaddresses(local_interface)[netifaces.AF_INET] ]
-                print_time("Adding addresses of local interface " + str(self.local_endpoint.interface) + " --> " + str(all_addrs), color)
-            except ValueError as err:
-                print_time("Cannot get IP addresses for " + str(self.local_endpoint.interface) + ": " + str(err), color)
+        if self.local_endpoint.interface is not None:
+            for local_interface in self.local_endpoint.interface:
+                try:
+                    # Unfortunately, listening on link-local IPv6 addresses does not work
+                    # because it's broken in asyncio: https://bugs.python.org/issue35545
+                    all_addrs += [ entry['addr'] for entry in netifaces.ifaddresses(local_interface)[netifaces.AF_INET6] if entry['addr'][:4] != "fe80" ]
+                    all_addrs += [ entry['addr'] for entry in netifaces.ifaddresses(local_interface)[netifaces.AF_INET] ]
+                    print_time("Adding addresses of local interface " + str(self.local_endpoint.interface) + " --> " + str(all_addrs), color)
+                except ValueError as err:
+                    print_time("Cannot get IP addresses for " + str(self.local_endpoint.interface) + ": " + str(err), color)
 
         # Get all combinations of protocols and remote IP addresses
         # to listen on all of them

--- a/pytaps/listener.py
+++ b/pytaps/listener.py
@@ -1,6 +1,7 @@
 import asyncio
 import ssl
 import ipaddress
+import netifaces
 from .connection import Connection
 from .securityParameters import SecurityParameters
 from .transportProperties import *
@@ -37,7 +38,7 @@ class Listener():
     async def start_listener(self):
         """ method wrapped by listen
         """
-        print_time("Starting listener.", color)
+        print_time("Starting listener with hostname: " + str(self.local_endpoint.host_name) + ", interface: " + str(self.local_endpoint.interface) + ", addresses: " + str(self.local_endpoint.address) + ".", color)
 
         # Create set of candidate protocols
         protocol_candidates = self.create_candidates()
@@ -66,15 +67,24 @@ class Listener():
             for cert in self.security_parameters.trustedCA:
                 self.security_context.load_verify_locations(cert)
 
-        if len(self.local_endpoint.address) < 1 and self.local_endpoint.host_name is not None:
-            # No address to listen on yet -- resolve hostname
+        all_addrs = []
+        if self.local_endpoint.host_name is not None:
             endpoint_info = await self.loop.getaddrinfo(
                 self.local_endpoint.host_name, self.local_endpoint.port)
-            all_addrs = list(set([ info[4][0] for info in endpoint_info]))
+            all_addrs += list(set([ info[4][0] for info in endpoint_info]))
             print_time("Resolved " + str(self.local_endpoint.host_name) + " to " + str(all_addrs), color)
-        else:
-            all_addrs = self.local_endpoint.address
-            print_time("Not resolving - using address(es) " + str(self.local_endpoint.address) + " --> " + str(all_addrs), color)
+        if len(self.local_endpoint.address) > 0:
+            all_addrs += self.local_endpoint.address
+            print_time("Adding addresses to listen: " + str(self.local_endpoint.address) + " --> " + str(all_addrs), color)
+        for local_interface in self.local_endpoint.interface:
+            try:
+                # Unfortunately, listening on link-local IPv6 addresses does not work
+                # because it's broken in asyncio: https://bugs.python.org/issue35545
+                all_addrs += [ entry['addr'] for entry in netifaces.ifaddresses(local_interface)[netifaces.AF_INET6] if entry['addr'][:4] != "fe80" ]
+                all_addrs += [ entry['addr'] for entry in netifaces.ifaddresses(local_interface)[netifaces.AF_INET] ]
+                print_time("Adding addresses of local interface " + str(self.local_endpoint.interface) + " --> " + str(all_addrs), color)
+            except ValueError as err:
+                print_time("Cannot get IP addresses for " + str(self.local_endpoint.interface) + ": " + str(err), color)
 
         # Get all combinations of protocols and remote IP addresses
         # to listen on all of them

--- a/pytaps/utility.py
+++ b/pytaps/utility.py
@@ -1,4 +1,5 @@
 import datetime
+import asyncio
 from enum import Enum
 from termcolor import colored
 


### PR DESCRIPTION
This PR:
- Enables Listeners to listen on one or multiple local interfaces = on all IP addresses configured on the interface(s)
- Enables Initiate() on specific local interface(s) = try all local IP addresses configured on the interface(s)

Future work: Race multiple local interfaces on Initiate() -- no time to try it